### PR TITLE
Display improvements from Monty

### DIFF
--- a/TEKTRONIX4051.js
+++ b/TEKTRONIX4051.js
@@ -1,4 +1,3 @@
-
 /*
  *
  * JSMSX - MSX Emulator in Javascript
@@ -406,13 +405,6 @@ function TEKTRONIX4051( window, canvas, logbuf ) {
 					GPIB_DATA_IN = this.sbytes[ this.sbytesindex ];
 					//console.log(" *** GPIB_DATA_IN " + GPIB_DATA_IN);
 					//console.log(" ** index = " + this.sbytesindex);
-					
-					while(GPIB_DATA_IN == 10) {
-					// TO DO - JBS 2/5/18 - why is LF causing problems now when it didn't before?
-					    console.log("Received unsupported LF character, skip!");
-					    this.sbytesindex++;
-					    GPIB_DATA_IN = this.sbytes[ this.sbytesindex ];
-					}
 					
 					// Is this the 'last' character?
 					//
@@ -862,7 +854,7 @@ function TEKTRONIX4051( window, canvas, logbuf ) {
 									var opb7 = (PIA_U461_ORB >>> 7) & 0x01;
 									var npb7 = (value             >>> 7) & 0x01;
 									if( opb7 != npb7 ) {
-										//!!! beep.play(); // This works - but not too well!
+										beep.play(); // This works - but not too well!
 									} // End if.
 									PIA_U461_ORB = value;
 									GPIB_EOI_OUT = (PIA_U461_ORB >>> 4) & 0x01;
@@ -1111,15 +1103,18 @@ function TEKTRONIX4051( window, canvas, logbuf ) {
     
     var int_interval;
     var exec_interval;
+    var dvst_emulate_interval;
 
     this.execute_start = function() {
-		exec_interval = setInterval( cpu.execute, 17 ); // 17ms == 60 intervals/sec
+		exec_interval = setInterval( cpu.execute, 1 ); // 1000 intervals per second
         int_interval = setInterval( interrupt, 1 );
+        dvst_emulate_interval = setInterval( display.dvst_emulate, 200 );
     }
     
     this.execute_stop = function() {
 		clearInterval( exec_interval );
         clearInterval( int_interval );
+        clearInterval( dvst_emulate_interval );
     }
     
     this.execute_reset = function() {

--- a/jsTEKTRONIX4051.html
+++ b/jsTEKTRONIX4051.html
@@ -31,10 +31,88 @@ big {color:red}
 
 <table>
 <tr>
-<td><canvas id="canvas" name="canvas" width="1024" height="780" style="border: medium solid ;"> </canvas></td>
+<td><canvas id="canvas" name="canvas" width="1030" height="792" style="border: medium solid ;"> </canvas></td>
 </tr>
 </table>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 11
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 12
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 13
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 14 
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 15
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp
+Compress&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+Rubout Left&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+Rubout Right&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+Reprint&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+Recall Next Line
+<br>	 
+<input id="FK1" value="    1    " onmousedown="javascript:tek_button(0x0070, 'keydown');" onmouseup="javascript:tek_button(0x0070, 'keyup');" type="button">
+<input id="FK2" value="    2    " onmousedown="javascript:tek_button(0x0071, 'keydown');" onmouseup="javascript:tek_button(0x0071, 'keyup');" type="button">
+<input id="FK3" value="    3    " onmousedown="javascript:tek_button(0x0072, 'keydown');" onmouseup="javascript:tek_button(0x0072, 'keyup');" type="button">
+<input id="FK4" value="    4    " onmousedown="javascript:tek_button(0x0073, 'keydown');" onmouseup="javascript:tek_button(0x0073, 'keyup');" type="button">
+<input id="FK5" value="    5    " onmousedown="javascript:tek_button(0x0074, 'keydown');" onmouseup="javascript:tek_button(0x0074, 'keyup');" type="button">
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp
+<input id="Expand" value="  Expand   " onmousedown="javascript:tek_button(0x0090, 'keydown');" onmouseup="javascript:tek_button(0x0090, 'keyup');" type="button">
+<input id="BackSpace" value="Back Space" onmousedown="javascript:tek_button(0x0091, 'keydown');" onmouseup="javascript:tek_button(0x0091, 'keyup');" type="button">
+<input id="Space" value="   Space   " onmousedown="javascript:tek_button(0x0092, 'keydown');" onmouseup="javascript:tek_button(0x0092, 'keyup');" type="button">
+<input id="Clear" value="   Clear   " onmousedown="javascript:tek_button(0x0093, 'keydown');" onmouseup="javascript:tek_button(0x007E, 'keyup');" type="button">
+<input id="RecallLine" value="Recall Line" onclick="javascript:tek_button(0x0094);" type="button">
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp
+<input id="AutoNum" value="Auto Number" onmousedown="javascript:tek_button(0x007F, 'keydown');" onmouseup="javascript:tek_button(0x007F, 'keyup');" type="button">
+<input id="StepPGM" value="Step Program" onmousedown="javascript:tek_button(0x0080, 'keydown');" onmouseup="javascript:tek_button(0x0080, 'keyup');" type="button">
+<br>
+--------------------- User Definable -----------------------
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp
+------------------------------------------ Line Editor --------------------------------------
+<br>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 16
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 17
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 18
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 19
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 20
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+Home
+<br>	 
+<input id="FK6" value="    6    " onmousedown="javascript:tek_button(0x0075, 'keydown');" onmouseup="javascript:tek_button(0x0075, 'keyup');" type="button">
+<input id="FK7" value="    7    " onmousedown="javascript:tek_button(0x0076, 'keydown');" onmouseup="javascript:tek_button(0x0076, 'keyup');" type="button">
+<input id="FK8" value="    8    " onmousedown="javascript:tek_button(0x0077, 'keydown');" onmouseup="javascript:tek_button(0x0077, 'keyup');" type="button">
+<input id="FK9" value="    9    " onmousedown="javascript:tek_button(0x0078, 'keydown');" onmouseup="javascript:tek_button(0x0078, 'keyup');" type="button">
+<input id="FK10" value="   10    " onmousedown="javascript:tek_button(0x0079, 'keydown');" onmouseup="javascript:tek_button(0x0079, 'keyup');" type="button">
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+<input id="Break" value="Break" onmousedown="javascript:tek_button(0x007D, 'keydown');" onmouseup="javascript:tek_button(0x007C, 'keyup');" type="button">
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+&nbsp;&nbsp;&nbsp;
+<input id="Page" value="Page" onmousedown="javascript:tek_button(0x007C, 'keydown');" onmouseup="javascript:tek_button(0x007C, 'keyup');" type="button">
 
+<br>
+
+<br>
 <br>
 
 <input id="start" value="start" onclick="javascript:tek_start();" type="button">
@@ -61,7 +139,14 @@ GPIB PROGRAM LOAD:
 <script language="JavaScript">
 
 var tek;
+/*
+window.setInterval(tek_BLINK, 600);
 
+function tek_BLINK() {
+
+    tek.execute_BLINK();
+} // End of function tek_blink.
+*/
 
 function tek_init() {
     
@@ -71,11 +156,16 @@ function tek_init() {
 
     var mycanvas    = document.getElementById('canvas');
     
-    var mycanvasctx = mycanvas.getContext("2d");
-    
-    tek = new TEKTRONIX4051( window, mycanvasctx, mylogbuf );
+    tek = new TEKTRONIX4051( window, mycanvas, mylogbuf );
     
 } // End of function tek_init.
+
+function tek_button(i, press) { 
+
+    var event = {keyCode:i, type:press, returnValue: false};
+    tek.execute_TekKeyboard.handleEvent.call(event);    
+    
+} // End of function tek_button.
 
 function tek_start() {
 

--- a/mc6800.js
+++ b/mc6800.js
@@ -58,10 +58,10 @@ function TekCpu(hw) {
     const MIPS = 0.833;
     
     // When the TekCpu object is created, its execute() function will
-    // be called 60 times per second in a SetInterval. To faithfully emulate
+    // be called 1000 times per second in a SetInterval. To faithfully emulate
     // the actual speed of a 6800, compute the number of instructions that will
     // be executed in one execute() function call interval.
-    const InstructionsPerInterval = (MIPS*1000000/60.0);
+    const InstructionsPerInterval = (MIPS*1000000/1000);
     //console.log("InstructionsPerInterval = " + InstructionsPerInterval);
 
     // Change this value to true if you want to see some processor executions logged to the console


### PR DESCRIPTION
Updated mc6800.js to run CPU on 1 ms intervals instead of 17 ms to bring the emulated processor MIPS closer to a continuous rate.

Pulled in Monty's blinking cursor idea and changed it to emulate DVST behavior instead fading the cursor out on 200 ms intervals. Not perfect, but closer to how real hardware works.

Fixed display.ERASE() to emulate actual hardware with a screen flash to erase and using more efficient method using putImageData instead of writing to all pixels individually.

Also has new graphical keyboard that Monty added, but they are non-functional.