### PR TITLE
Enabled Edit Keys

### DIFF
--- a/TekKeyboard.js
+++ b/TekKeyboard.js
@@ -125,11 +125,11 @@ function TekKeyboard(hw, window) {
 		  case 0x0079 : i = 0x69; break; // FK10  
 		  
 		  // Line editing keys.
-//		  case 0x0000 : i = 0x70; break; // EXPAND
-//		  case 0x0000 : i = 0x71; break; // BK SPACE
-//		  case 0x0000 : i = 0x72; break; // SPACE
-		  case 0x007E : i = 0x73; break; // <f15> = CLEAR
-//		  case 0x0000 : i = 0x74; break; // RECALL
+		  case 0x0090 : i = 0x70; break; // EXPAND
+		  case 0x0091 : i = 0x71; break; // BK SPACE
+		  case 0x0092 : i = 0x72; break; // SPACE
+		  case 0x0093 : i = 0x73; break; // <f15> = CLEAR
+		  case 0x0094 : i = 0x74; break; // RECALL
 
 
 		  // Tape control keys.

--- a/jsTEKTRONIX4051.html
+++ b/jsTEKTRONIX4051.html
@@ -75,8 +75,9 @@ big {color:red}
 <td><input id="Space" value="  Space  " onmousedown="javascript:tek.execute_fcnkey(0x0092, true);" 
                                         onmouseup="javascript:tek.execute_fcnkey(0x0092, false);" type="button"></td>
 <td><input id="Clear" value="   Clear   " onmousedown="javascript:tek.execute_fcnkey(0x0093, true);" 
-                                          onmouseup="javascript:tek.execute_fcnkey(0x007E, false);" type="button"></td>
-<td><input id="RecallLine" value="  Recall Line  " onclick="javascript:tek.execute_fcnkey(0x0094);" type="button"></td></tr>
+                                          onmouseup="javascript:tek.execute_fcnkey(0x0093, false);" type="button"></td>
+<td><input id="RecallLine" value="  Recall Line  " onmousedown="javascript:tek.execute_fcnkey(0x0094,true);"
+											       onmouseup="javascript:tek.execute_fcnkey(0x0094, false);" type="button"></td>
 <tr><td colspan="7">------------------------------------------ Line Editor --------------------------------------</td></tr>
 </table>
 


### PR DESCRIPTION
Updated Keyboard.js with Edit Key codes
Fixed jsTEKTRONIX4051.html scan code for Recall Line edit key

They all work now.

load emulator
press Auto Number
type anything after 100
use Back Space edit key to back up in middle of text
use Expand to open space in text
use Compress to close space in text
use Clear to go to new line without saving changes